### PR TITLE
Adjustments for moved repos

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -314,19 +314,19 @@ module.exports = function (grunt) {
             thriftLib1: {
                 files: [
                     {
-                        cwd: 'node_modules/kbase-data-thrift-clients/libs/javascript/taxonomy/taxon',
+                        cwd: 'bower_components/kbase-data-thrift-clients/libs/javascript/taxonomy/taxon',
                         src: 'taxon_types.js',
                         dest: makeBuildPath('kb/data/taxon'),
                         expand: true
                     },
                     {
-                        cwd: 'node_modules/kbase-data-thrift-clients/libs/javascript/sequence/assembly',
+                        cwd: 'bower_components/kbase-data-thrift-clients/libs/javascript/sequence/assembly',
                         src: 'assembly_types.js',
                         dest: makeBuildPath('kb/data/assembly'),
                         expand: true
                     },
                     {
-                        cwd: 'node_modules/kbase-data-thrift-clients/libs/javascript/annotation/genome_annotation',
+                        cwd: 'bower_components/kbase-data-thrift-clients/libs/javascript/annotation/genome_annotation',
                         src: 'genome_annotation_types.js',
                         dest: makeBuildPath('kb/data/genomeAnnotation'),
                         expand: true
@@ -341,19 +341,19 @@ module.exports = function (grunt) {
             thriftLib2: {
                 files: [
                     {
-                        cwd: 'node_modules/kbase-data-thrift-clients/libs/javascript/taxonomy/taxon',
+                        cwd: 'bower_components/kbase-data-thrift-clients/libs/javascript/taxonomy/taxon',
                         src: 'thrift_service.js',
                         dest: makeBuildPath('kb/data/taxon'),
                         expand: true
                     },
                     {
-                        cwd: 'node_modules/kbase-data-thrift-clients/libs/javascript/sequence/assembly',
+                        cwd: 'bower_components/kbase-data-thrift-clients/libs/javascript/sequence/assembly',
                         src: 'thrift_service.js',
                         dest: makeBuildPath('kb/data/assembly'),
                         expand: true
                     },
                     {
-                        cwd: 'node_modules/kbase-data-thrift-clients/libs/javascript/annotation/genome_annotation',
+                        cwd: 'bower_components/kbase-data-thrift-clients/libs/javascript/annotation/genome_annotation',
                         src: 'thrift_service.js',
                         dest: makeBuildPath('kb/data/genomeAnnotation'),
                         expand: true

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 # and not an official supported build step.
 
 default: test
+	
+init:
+	npm install
 
 build:
 	grunt build

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,8 @@
     "bootstrap": "3.3.5",
     "require-css": "0.1.8",
     "font-awesome": "4.4.0",
-    "requirejs-json": "^0.0.3"
+    "requirejs-json": "^0.0.3",
+    "kbase-data-thrift-clients": "^1.0.0"
   },
   "license": "SEE LICENSE IN LICENSE"
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "karma-requirejs": "0.2.3",
     "karma-safari-launcher": "0.1.1",
     "karma-spec-reporter": "0.0.21",
-    "kbase-data-thrift-clients": "0.1.0",
     "requirejs": "2.1.22"
   },
   "repository": {


### PR DESCRIPTION
When making adjustments to the bower and npm registries after moving the data-api oriented repos into kbase, I found that the sole npm registered repo, kbase-data-thrift-clients, was going to be a pain. This is because npm requires a new version bump if a repo is moved, and also requires extra manual steps when updating the repo for a package. All in all, it was much easier just to register the repo in bower instead, and make a few adjustments in the data api js clients package. Specifically, the generated clients were removed from package.json, added to bower.json, and the grunt file adjusted to pick up the changes from the bower_components tree rather than node_modules.
If this change is accepted, then a version bump would be nice to get this incorporated into kbase-ui. It has been tested there locally.
