### PR TITLE
make bluebird bower semver looser

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "url": "git://github.com/kbase/kbase-data-api-js-clients"
   },
   "dependencies": {
-    "bluebird": "~3.1.0",
+    "bluebird": "^3.1.0",
     "requirejs": "^2.0.0",
     "kbase-common-js": "^1.0.0",
     "kbase-service-clients-js": "^1.0.0",


### PR DESCRIPTION
It was set to ~3.1.0 which restricts it to the 3.1.x branch, we need
it to ^3.0.0 so we can keep the UI more up to date with promises fixes.
